### PR TITLE
Use SubBus for the core0 task

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,35 @@ cortex-m-rt = "0.7.3"
 critical-section = "1.1.3"
 defmt = "0.3.8"
 defmt-rtt = "0.4.1"
-embassy-executor = { version = "0.6.0", features = ["task-arena-size-98304", "arch-cortex-m", "executor-thread", "executor-interrupt", "defmt", "integrated-timers"] }
+embassy-executor = { version = "0.6.0", features = [
+    "task-arena-size-98304",
+    "arch-cortex-m",
+    "executor-thread",
+    "executor-interrupt",
+    "defmt",
+    "integrated-timers",
+] }
 embassy-futures = { version = "0.1.1", features = ["defmt"] }
-embassy-rp = { version = "0.2.0", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"] }
+embassy-rp = { version = "0.2.0", features = [
+    "defmt",
+    "unstable-pac",
+    "time-driver",
+    "critical-section-impl",
+] }
 embassy-sync = { version = "0.6.0", features = ["defmt"] }
-embassy-time = { version = "0.3.2", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-time = { version = "0.3.2", features = [
+    "defmt",
+    "defmt-timestamp-uptime",
+] }
 embedded-hal = { version = "1.0.0", features = ["defmt-03"] }
 embedded-hal-async = { version = "1.0.0", features = ["defmt-03"] }
 itoa = { version = "1.0.11", features = ["no-panic"] }
 panic-probe = { version = "0.3.2", features = ["print-defmt"] }
 # pca9548a = "0.1.0"
-pca9548a = { git = "https://github.com/Phosfor/pca9548a.git", branch = "feature-embassy" , features = ["embassy"] }
+pca9548a = { git = "https://github.com/Phosfor/pca9548a.git", branch = "feature-embassy", features = [
+    "embassy",
+    "async-to-sync",
+] }
 portable-atomic = { version = "1.8.0", features = ["critical-section"] }
 ssd1306 = { version = "0.9.0", features = ["async"] }
 static_cell = "2.1.0"


### PR DESCRIPTION
Here are the changes necessary to get your project to compile. You might need to run `cargo update` in order to get the latest changes from the pca9548a crate. This should compile, but I don't have the hardware laying around right now so I cannot run and test it.

There seem to be a lot of changes, but most of it is formatting (sorry, I didn't notice that before committing; I would also highly recommend autoformatting before every commit, maybe even configuring your editor to format on save).
The important changes are
- Cargo.toml:40 Add the "async-to-sync" feature. This allows using the synchronous API with an async mutex.
- main.rs:36-37,61 Store the Pca9548a struct in a StaticCell. This is needed so the lifetime in the SubBus struct becomes 'static
- main.rs:81 Adjust the type of the parameter to be SubBus<...>